### PR TITLE
[FIX] Remove dead 'Setting up the CLI' link

### DIFF
--- a/src/templates/doc.hbs
+++ b/src/templates/doc.hbs
@@ -24,7 +24,6 @@
             <li><h4>Using Codius</h4>
               <ul class="nav nav-stacked">
                 <li><a href="/docs/using-codius/getting-started">Getting started</a></li>
-                <li><a href="/docs/using-codius/setup-cli">Setting up the CLI</a></li>
                 <li><a href="/docs/using-codius/running-the-examples">Running the examples</a></li>
                 <li><a href="/docs/using-codius/writing-a-contract">Writing a contract</a></li>
               </ul>


### PR DESCRIPTION
[Fixes #89130074]
